### PR TITLE
fix bug crawlCv-v2

### DIFF
--- a/aspnet-core/src/TalentV2.Core/BackgroundWorker/CrawlCVFromFirebaseWorker.cs
+++ b/aspnet-core/src/TalentV2.Core/BackgroundWorker/CrawlCVFromFirebaseWorker.cs
@@ -10,15 +10,12 @@ using NccCore.Extension;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Policy;
 using System.Text;
 using TalentV2.Configuration;
 using TalentV2.Constants.Enum;
 using TalentV2.DomainServices.CVAutomation;
-using TalentV2.DomainServices.CVAutomation.Dto;
 using TalentV2.Utils;
 using TalentV2.WebServices.ExternalServices.Komu;
-using static Castle.MicroKernel.ModelBuilder.Descriptors.InterceptorDescriptor;
 
 namespace TalentV2.BackgroundWorker
 {
@@ -189,7 +186,6 @@ namespace TalentV2.BackgroundWorker
     ? "Please check the created CV information at Talent."
     : "Please check the created CV information at the attached link.\n");
             }
-            sb.AppendLine($": {GetTalentLink(clientUrl, UserType.Intern)}");
             return sb.ToString();
         }
 

--- a/aspnet-core/src/TalentV2.Core/Constants/Const/FirebaseLogStatusConstant.cs
+++ b/aspnet-core/src/TalentV2.Core/Constants/Const/FirebaseLogStatusConstant.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace TalentV2.Constants.Const
+﻿namespace TalentV2.Constants.Const
 {
     public class FirebaseLogStatusConstant
     {
@@ -12,5 +6,6 @@ namespace TalentV2.Constants.Const
         public const string NOT_ENOUGH_INFO = "not_enough_info";
         public const string CV_SIZE_TOO_BIG = "cv_size_too_big";
         public const string CV_ERROR_TYPE = "cv_type_not_supported";
+        public const string CV_ERROR_AT_EXTRACTING = "cv_error_at_extracting";
     }
 }

--- a/aspnet-core/src/TalentV2.Core/WebServices/ExternalServices/Autobot/AutobotService.cs
+++ b/aspnet-core/src/TalentV2.Core/WebServices/ExternalServices/Autobot/AutobotService.cs
@@ -172,7 +172,7 @@ namespace TalentV2.WebServices.ExternalServices.Autobot
                     {
                         content.Add(new ByteArrayContent(fileBytes), "file", fileName);
                         var response = await HttpClient.PostAsync(requestUrl, content);
-                        if (response.StatusCode == HttpStatusCode.TooManyRequests)
+                        if (response.StatusCode == HttpStatusCode.TooManyRequests || response.StatusCode >= HttpStatusCode.InternalServerError)
                         {
                             attempt++;
                             if (attempt == maxRetries)


### PR DESCRIPTION
1. Fix the infinite loop in SendFileToCVExtractionAsync():
     - Add a break; in the catch clause to prevent the loop from running indefinitely when an exception occurs.
     - If the status code is 429 (TooManyRequests), start the delay logic and retry.
     - If the status code is 200 (OK), continue with the logic and return the result.
     - For any other status code, break the loop and return null.
     
2. Adjust retry settings:
     - Change the retry attempts from 5 to 3.
     - Set the maximum delay time from 60 seconds to 40 seconds.
     - Fix the step delay times to follow this sequence: 20 seconds -> 40 seconds -> 40 seconds.
     
3. Add a constant cv_error_at_extracting in FirebaseLogStatusConstant and add an additional check after the extraction to log when a CV is not extracted successfully.

4. Delete the line: sb.AppendLine($": {GetTalentLink(clientUrl, UserType.Intern)}");
    - This was missed in the last commit and needs to be removed.